### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Use the official Go image
+FROM golang:latest
+
+# Set the working directory inside the container
+WORKDIR /app
+
+# Copy the Carrion source code into the container
+COPY . .
+
+# Run the setup script
+RUN chmod +x setup.sh
+CMD ["./setup.sh"]


### PR DESCRIPTION
This pull request adds a Dockerfile to the 'MuninStdLib' branch, allowing Carrion to be run using a Go image. The Dockerfile is configured to execute the 'setup.sh' script, ensuring proper setup and execution of Carrion within a Docker container.