### PR TITLE
Sort package versions using semantic versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,16 @@ go 1.23.0
 
 toolchain go1.24.2
 
-require github.com/peterh/liner v1.2.2
+require (
+        github.com/peterh/liner v1.2.2
+        golang.org/x/mod v0.25.0
+)
 
 require (
-	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/mattn/go-runewidth v0.0.3 // indirect
-	golang.org/x/mod v0.25.0 // indirect
-	golang.org/x/sync v0.15.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/tools v0.34.0 // indirect
-	mvdan.cc/gofumpt v0.8.0 // indirect
+        github.com/google/go-cmp v0.7.0 // indirect
+        github.com/mattn/go-runewidth v0.0.3 // indirect
+        golang.org/x/sync v0.15.0 // indirect
+        golang.org/x/sys v0.33.0 // indirect
+        golang.org/x/tools v0.34.0 // indirect
+        mvdan.cc/gofumpt v0.8.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/peterh/liner v1.2.2 h1:aJ4AOodmL+JxOZZEL2u9iJf8omNRpqHc/EbrK+3mAXw=
 github.com/peterh/liner v1.2.2/go.mod h1:xFwJyiKIXJZUKItq5dGHZSTBRAuG/CpeNpWLyiNRNwI=
 golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
 golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=

--- a/src/evaluator/evaluator.go
+++ b/src/evaluator/evaluator.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"golang.org/x/mod/semver"
 
 	"github.com/javanhut/TheCarrionLanguage/src/ast"
 	"github.com/javanhut/TheCarrionLanguage/src/debug"
@@ -4339,15 +4341,26 @@ func getLatestPackageVersion(packagePath string) ([]string, error) {
 		return nil, err
 	}
 	
-	var versions []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			versions = append(versions, entry.Name())
-		}
-	}
-	
-	// TODO: Sort by semantic version - for now just return alphabetical
-	return versions, nil
+        var versions []string
+        for _, entry := range entries {
+                if entry.IsDir() {
+                        versions = append(versions, entry.Name())
+                }
+        }
+
+        sort.Slice(versions, func(i, j int) bool {
+                vi := versions[i]
+                vj := versions[j]
+                if !strings.HasPrefix(vi, "v") {
+                        vi = "v" + vi
+                }
+                if !strings.HasPrefix(vj, "v") {
+                        vj = "v" + vj
+                }
+                return semver.Compare(vi, vj) > 0
+        })
+
+        return versions, nil
 }
 
 func evalImportStatement(


### PR DESCRIPTION
## Summary
- order package version directories using semantic version precedence
- depend on `golang.org/x/mod` for semantic version comparison

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6896c0c32f9083208e58da40370b84f6